### PR TITLE
Add Dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # This points to .github/workflows
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
- Adds .github/dependabot.yml to enable automated dependency updates via GitHub Dependabot. It is configured to:

  Monitor GitHub Actions workflow dependencies (.github/workflows/)
  Check for updates daily and automatically open PRs when newer versions of used actions are available
  This ensures CI/CD workflows always use up-to-date, patched versions of GitHub Actions, reducing exposure to known vulnerabilities in third-party actions.